### PR TITLE
PP9-9656 - Content Picker: Open per default with mobile settings on desktop

### DIFF
--- a/src/picturepark-sdk-v1-angular/projects/picturepark-sdk-v1-angular-ui/src/lib/features-module/content-browser/content-browser.component.html
+++ b/src/picturepark-sdk-v1-angular/projects/picturepark-sdk-v1-angular-ui/src/lib/features-module/content-browser/content-browser.component.html
@@ -23,29 +23,18 @@
        [class.browser__items--large]="activeView.type === 'thumbnailLarge'"
        [class.browser__items--medium]="activeView.type === 'thumbnailMedium'" cdkScrollable>
     <div class="browser__item-container" *ngFor="let itemModel of items; let i = index; trackBy: trackByItem">
-      <ng-container *ngIf="deviceBreakpoint;else desktop">
-        <pp-content-browser-item 
-        class="browser__item" 
-        [browser]="self"
-        [itemModel]="itemModel" 
-        [thumbnailSize]="activeThumbnailSize" 
-        [isListView]="activeView.type === 'list'" 
-        (previewItemChange)="previewItem($event)"
-        (press)="itemClicked($event,i)" 
-        (tap)="selectedItems.length ? itemClicked($event, i) : previewItem(itemModel)">
+      <ng-container *ngIf="deviceBreakpoint && isTouchDevice;else desktop">
+        <pp-content-browser-item class="browser__item" [browser]="self" [itemModel]="itemModel"
+          [thumbnailSize]="activeThumbnailSize" [isListView]="activeView.type === 'list'"
+          (previewItemChange)="previewItem($event)" (press)="itemClicked($event,i)"
+          (tap)="selectedItems.length ? itemClicked($event, i) : previewItem(itemModel)">
         </pp-content-browser-item>
       </ng-container>
 
       <ng-template #desktop>
-        <pp-content-browser-item 
-        class="browser__item" 
-        [browser]="self"
-        [itemModel]="itemModel" 
-        [thumbnailSize]="activeThumbnailSize" 
-        [isListView]="activeView.type === 'list'" 
-        (previewItemChange)="previewItem($event)"
-        (click)="itemClicked($event,i)" 
-        (dblclick)="previewItem(itemModel)">
+        <pp-content-browser-item class="browser__item" [browser]="self" [itemModel]="itemModel"
+          [thumbnailSize]="activeThumbnailSize" [isListView]="activeView.type === 'list'"
+          (previewItemChange)="previewItem($event)" (click)="itemClicked($event,i)" (dblclick)="previewItem(itemModel)">
         </pp-content-browser-item>
       </ng-template>
     </div>
@@ -54,7 +43,7 @@
   <div *ngIf="totalResults === 0" class="browser__empty-result mat-typography">
     {{ 'ContentBrowser.NoItems' | pptranslate }}
     <strong> {{ searchString }}</strong>
-    <br/>
+    <br />
     {{ 'ContentBrowser.NoItemsHist' | pptranslate }}
     <ul>
       <li>{{ 'ContentBrowser.NoItemsActionChannel' | pptranslate }}</li>

--- a/src/picturepark-sdk-v1-angular/projects/picturepark-sdk-v1-angular-ui/src/lib/shared-module/components/browser-base/browser-base.component.ts
+++ b/src/picturepark-sdk-v1-angular/projects/picturepark-sdk-v1-angular-ui/src/lib/shared-module/components/browser-base/browser-base.component.ts
@@ -69,6 +69,10 @@ export abstract class BaseBrowserComponent<TEntity extends IEntityBase> extends 
         return this.breakpointObserver.isMatched([Breakpoints.Handset, Breakpoints.Tablet]);
     }
 
+    public get isTouchDevice(): boolean {
+        return (('ontouchstart' in window) || (navigator.maxTouchPoints > 0) || (navigator.msMaxTouchPoints > 0));
+    }
+
     protected scrollDebounceTime = 0;
 
     @Output() public totalResultsChange = new EventEmitter<number | null>();
@@ -85,7 +89,7 @@ export abstract class BaseBrowserComponent<TEntity extends IEntityBase> extends 
     abstract init(): Promise<void>;
     abstract initSort(): void;
     abstract onScroll(): void;
-    abstract getSearchRequest(): Observable<{results: TEntity[]; totalResults: number; pageToken?: string | undefined }> | undefined;
+    abstract getSearchRequest(): Observable<{ results: TEntity[]; totalResults: number; pageToken?: string | undefined }> | undefined;
     abstract checkContains(elementClassName: string): boolean;
 
     constructor(protected componentName: string,
@@ -161,7 +165,7 @@ export abstract class BaseBrowserComponent<TEntity extends IEntityBase> extends 
         this.nextPageToken = undefined;
         this.items = [];
         this.loadData();
-      }
+    }
 
     public loadData(): void {
         const request = this.getSearchRequest();
@@ -208,9 +212,9 @@ export abstract class BaseBrowserComponent<TEntity extends IEntityBase> extends 
             this.lastSelectedIndex = index;
 
             if (itemModel.isSelected === true) {
-            this.contentItemSelectionService.removeItem(itemModel.item);
+                this.contentItemSelectionService.removeItem(itemModel.item);
             } else {
-            this.contentItemSelectionService.addItem(itemModel.item);
+                this.contentItemSelectionService.addItem(itemModel.item);
             }
         } else if ($event.shiftKey) {
             const firstIndex = this.lastSelectedIndex < index ? this.lastSelectedIndex : index;


### PR DESCRIPTION
Added a method in the content browser base component to detect if the device is touch-enabled
Used that method to open the content picker in touch mode or not