### PR TITLE
PP9-12762 - Share page: Expired notice has header panel with solid bottom border and spelling mistake

### DIFF
--- a/src/picturepark-sdk-v1-angular/projects/share-viewer/src/app/share-detail/share-detail.component.html
+++ b/src/picturepark-sdk-v1-angular/projects/share-viewer/src/app/share-detail/share-detail.component.html
@@ -43,7 +43,7 @@
     </div>
   </pp-panel>
 
-  <pp-panel *ngIf="shareDetail.expired">
+  <pp-panel *ngIf="shareDetail.expired" [showHeader]="false">
     <div pp-panel-content class="expired-box">
       {{ 'ShareViewer.Expired' | pptranslate }}
     </div>

--- a/src/picturepark-sdk-v1-angular/projects/share-viewer/src/app/translations/share-translations.ts
+++ b/src/picturepark-sdk-v1-angular/projects/share-viewer/src/app/translations/share-translations.ts
@@ -2,7 +2,7 @@ export const shareTranslations = {
   Expired: {
     en: 'This share has expired and is no longer available. Please contact the person who sent you this link.',
     de:
-      'Dieses Share ist abgelaufen und nicht mehr länger verfügbar. Bitte kontaktieren Sie die Person, dwelche Ihnen diesen Link geschickt hat.',
+      'Dieses Share ist abgelaufen und nicht mehr länger verfügbar. Bitte kontaktieren Sie die Person, welche Ihnen diesen Link geschickt hat.',
     fr:
       "Cette collection partagée a expiré et n'est plus disponible. Veuillez contacter la personne qui vous a envoyé ce lien s.v.p.",
     es:


### PR DESCRIPTION
 - panel header hidden for share expired notice
 - share expired german translation typo fixed