### PR TITLE
PP9-12755 - Excel Roundtrip: Sort in Content Browser is initially always set to relevance

### DIFF
--- a/src/picturepark-sdk-v1-angular/projects/picturepark-sdk-v1-angular-ui/src/lib/features-module/content-browser/content-browser.component.ts
+++ b/src/picturepark-sdk-v1-angular/projects/picturepark-sdk-v1-angular-ui/src/lib/features-module/content-browser/content-browser.component.ts
@@ -86,8 +86,8 @@ export class ContentBrowserComponent extends BaseBrowserComponent<Content> imple
         sortDirection = this.channel.sort[0].direction;
       }
 
-      this.activeSortingType = sortField ?? this.sortingTypes[0];
       this.isAscending = sortDirection ? sortDirection === SortDirection.Asc : false;
+      this.setSort(sortField ?? this.sortingTypes[0], this.isAscending, false);
     }
   }
 
@@ -97,6 +97,8 @@ export class ContentBrowserComponent extends BaseBrowserComponent<Content> imple
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['channel'] && changes['channel'].currentValue) {
+      this.setSortFields();
+
       this.facade.searchRequestState.channelId = this.channel!.id;
       // Trigger load
       if (this.channel?.aggregations) {
@@ -104,8 +106,6 @@ export class ContentBrowserComponent extends BaseBrowserComponent<Content> imple
       } else {
         this.facade.patchRequestState({});
       }
-
-      this.setSortFields();
     }
   }
 


### PR DESCRIPTION
 - Content Browser: fixed the sort order of the selected channel being applied after the searchRequest is patched, which means the content search was being performed before the sort order was set.